### PR TITLE
update readme to use version with fixed entrypoint permissions

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ No Outputs
 ## Example usage
 
 ```yaml
-- uses: jackbilestech/semver-compare@1.0.0
+- uses: jackbilestech/semver-compare@1.0.4
   with:
     head: '2.0.0'
     base: '1.0.0'


### PR DESCRIPTION
Was having issues with entrypoint.sh permissions using GitHub Action as detailed in README  and on Marketplace.

Noticed that a patch had been applied in `1.0.4.` that resolved the issue.